### PR TITLE
Skip comments correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,11 +37,21 @@ function requires(str, fn) {
  */
 
 function map(str, fn) {
-  requires(str).forEach(function(r){
-    str = str.replace(r.string, fn(r));
-  });
+  var result = '';
+  var offset = 0;
 
-  return str;
+  requires(str).forEach(function(r) {
+    var start = r.index - offset;
+    var end = start + r.string.length;
+
+    result += str.substr(0, start);
+    result += fn(r);
+    offset += end;
+    str = str.substr(end);
+  });
+  result += str;
+
+  return result;
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function requires(str, fn) {
   var ret = [];
   var m;
 
-  str = stripComments(str);
+  str = replaceComments(str);
   while (m = re.exec(str)) {
     ret.push({
       string: m[0],
@@ -45,9 +45,11 @@ function map(str, fn) {
 }
 
 /**
- * Strip comments.
+ * Replace comments with blanks to preserve offsets
  */
 
-function stripComments(str) {
-  return str.replace(/\/\*[\S\s]*?\*\/|\/\/.*/g, '');
+function replaceComments(str) {
+  return str.replace(/\/\*[\S\s]*?\*\/|\/\/.*/g, function(match) {
+    return Array(match.length + 1).join(' ');
+  });
 }

--- a/test/fixtures/comment.js
+++ b/test/fixtures/comment.js
@@ -1,8 +1,7 @@
+// inline comment require('./a.js');
 
-// require('./a.js');
+startCode; require('./a.js'); endCode;
 
-require('./b.js');
-
-/* 
-  require('./c');
+/*
+  multiline comment require('./a.js');
 */

--- a/test/index.js
+++ b/test/index.js
@@ -47,7 +47,7 @@ describe('requires(str, fn)', function(){
       return 'require("woot/' + require.path + '")';
     });
 
-    str.should.include('var a = require("woot/./a.js");');
-    str.should.include('var b = require("woot/./something/here/whoop");');
+    str.should.containEql('var a = require("woot/./a.js");');
+    str.should.containEql('var b = require("woot/./something/here/whoop");');
   })
 })

--- a/test/index.js
+++ b/test/index.js
@@ -32,9 +32,9 @@ describe('requires(str)', function(){
 
     ret.length.should.eql(1);
     ret[0].should.eql({
-      string: "require('./b.js')",
-      path: './b.js',
-      index: 24
+      string: "require('./a.js')",
+      path: './a.js',
+      index: 49
     });
     a.substr(ret[0].index, ret[0].string.length).should.eql(ret[0].string);
   });
@@ -50,5 +50,17 @@ describe('requires(str, fn)', function(){
 
     str.should.containEql('var a = require("woot/./a.js");');
     str.should.containEql('var b = require("woot/./something/here/whoop");');
-  })
+  });
+
+  it('should skip require in comments', function(){
+    var a = fs.readFileSync('test/fixtures/comment.js', 'utf8');
+
+    var str = requires(a, function(require){
+      return 'require("woot/' + require.path + '")';
+    });
+
+    str.should.containEql("// inline comment require('./a.js');");
+    str.should.containEql('startCode; require("woot/./a.js"); endCode;');
+    str.should.containEql("multiline comment require('./a.js');");
+  });
 })

--- a/test/index.js
+++ b/test/index.js
@@ -34,15 +34,16 @@ describe('requires(str)', function(){
     ret[0].should.eql({
       string: "require('./b.js')",
       path: './b.js',
-      index: 3
+      index: 24
     });
+    a.substr(ret[0].index, ret[0].string.length).should.eql(ret[0].string);
   });
 })
 
 describe('requires(str, fn)', function(){
   it('should replace requires', function(){
     var a = fs.readFileSync('test/fixtures/a.js', 'utf8');
-    
+
     var str = requires(a, function(require){
       return 'require("woot/' + require.path + '")';
     });


### PR DESCRIPTION
Current implementation has some bugs with comments parsing.
1. After using `stripComments` indexes is totally broken.
2. Library counts how many occurrences of `require` string has in code part (except comments) and then replaces string exact times, **including comments**. It replaces in comments and misses in code.

``` js
// require("fooBar");
require("fooBar");
```

Library will replace first and miss second one.

`component.io` forgets to rewrite some URLs because of it.
